### PR TITLE
UPDATE system_overview/minibolt.sh

### DIFF
--- a/get_CLN_data.sh
+++ b/get_CLN_data.sh
@@ -20,7 +20,7 @@ else
     ln_running="up"
   fi
 fi
-lncli="/home/lightningd/lightning/cli/lightning-cli"
+lncli="/usr/local/bin/lightning-cli"
 
 printf "%0.s#" {1..63}
 echo -ne '\r### Loading CoreLN data \r'
@@ -130,8 +130,7 @@ else
 fi
 
 #get channel.db size
-coreln_dir="/data/lightningd"
-ln_channel_db_size=$(du -h ${coreln_dir}/bitcoin/lightningd.sqlite3 | awk '{print $1}')
+ln_channel_db_size=$(sudo su - postgres -c "psql -At -d clndb -c \"SELECT pg_size_pretty(pg_database_size('clndb'));\"")
 
 # Write to JSON file
 lnd_infofile="${HOME}/.minibolt.lndata.json"

--- a/get_CLN_data.sh
+++ b/get_CLN_data.sh
@@ -37,7 +37,7 @@ ln_walletbalance=0
 #check if len(outputs) == 0 --> empty wallet
 amount_of_wallet_transactions=$(echo ${lncli_listfunds} | jq -r '.outputs | length')
 if [ $amount_of_wallet_transactions -gt 0 ];then
-ln_walletbalance=$(echo ${lncli_listfunds} | jq -r '.outputs[0].value | tonumber')
+ln_walletbalance=$(echo ${lncli_listfunds} | jq -r '.outputs[0].amount_msat | tonumber | . / 1000')
 fi
 
 ## Show channel balance

--- a/minibolt.sh
+++ b/minibolt.sh
@@ -786,9 +786,12 @@ if [ "$rtl_status" = "active" ]; then
   if [ "$rtl_status" = "active" ]; then
     lwserver_running="up"
     lwserver_color="${color_green}"
-    rtlpi=v$(cd /home/${un_rtl}/RTL; npm version | grep -oP "rtl: '\K(.*)(?=-beta')")
+    # Get the full version string including "-beta"
+    rtlpi_full=v$(sudo head -n 3 /home/rtl/RTL/package.json | grep -oE '"version": "[0-9.]+(-beta)?"' | awk -F'"' '{print $4}')
+    # Extract just the version number for comparison
+    rtlpi=$(echo "$rtlpi_full" | sed 's/-beta//')
     if [ "$rtlpi" = "$rtlgit" ]; then
-      lwserver_version="$rtlpi"
+      lwserver_version="$rtlpi_full"  # Use the full version with "-beta"
       lwserver_version_color="${color_green}"
     else
       lwserver_version="${rtlpi} to ${rtlgit}"

--- a/minibolt.sh
+++ b/minibolt.sh
@@ -664,7 +664,13 @@ if [ "$electrs_status" = "active" ]; then
     eserver_running="up"
     eserver_color="${color_green}"
     # Request params are client_name, protocol_version. Example result being parsed: ["Electrs 0.9.10", "1.4"]
-    electrspi=$(echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "minibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 50001 -q 1 | jq -r '.result[0]' | awk '{print "v"substr($1,9)}')
+    # Try both ports 50001 and 50021
+    for port in 50001 50021; do
+      electrspi=$(echo '{"jsonrpc": "2.0", "method": "server.version", "params": [ "minibolt", "1.4" ], "id": 0}' | netcat 127.0.0.1 $port -q 1 | jq -r '.result[0]' | awk '{print "v"substr($1,9)}' 2>/dev/null)
+      if [ -n "$electrspi" ]; then
+        break  # Exit loop if a version is found
+      fi
+    done
     if [ "$electrspi" = "$electrsgit" ]; then
       eserver_version="$electrspi"
       eserver_version_color="${color_green}"


### PR DESCRIPTION
Currently if a user configures Electrs to use port ```50021``` as per the guide, then System Overview will not correctly display the status because it is hardcoded to check for port ```50001```.  This commit updates ```minibolt.sh``` to check for both ports.

Current status:
![Screenshot 2024-12-15 115725](https://github.com/user-attachments/assets/9d1ed7f3-822f-4bfd-9d5e-65dfaa78f00e)

Status with commit:
![Screenshot 2024-12-15 115747](https://github.com/user-attachments/assets/4e185332-093d-4b3a-ac7e-80e436f6880c)
